### PR TITLE
Remove flag_fixed_debug_line_info duplicate initialization in toplev.c

### DIFF
--- a/gcc/toplev.c
+++ b/gcc/toplev.c
@@ -594,9 +594,6 @@ int flag_prologue_bugfix = 0;
 /* Fix buggy DWARF line info generation.  */
 int flag_fixed_debug_line_info = 0;
 
-/* Fix prologue bug in new compiler.  */
-int flag_prologue_bugfix = 0;
-
 typedef struct
 {
     char *string;


### PR DESCRIPTION
I got a build error due to the duplicate declaration of flag_fixed_debug_line_info in toplev.c. After removing it, the build was successful.